### PR TITLE
fix(SDK) fixes location.protocol check

### DIFF
--- a/js/src/Ui.js
+++ b/js/src/Ui.js
@@ -157,7 +157,7 @@ export default class Ui extends lng.Application {
     }
 
     static _getCdnProtocol() {
-        return lng.Utils.isWeb && location.protocol === "https" ? "https" : "http";
+        return lng.Utils.isWeb && location.protocol === "https:" ? "https" : "http";
     }
 
     static hasOption(name) {


### PR DESCRIPTION
location.protocol has a ':' in the end of the string, so this change properly fixes the check

reference:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/protocol