### PR TITLE
Fixed issue, where ScaledImageTexture would preserve only one image p…

### DIFF
--- a/js/src/ScaledImageTexture.js
+++ b/js/src/ScaledImageTexture.js
@@ -14,6 +14,11 @@ export default class ScaledImageTexture extends lng.textures.ImageTexture {
         }
     }
 
+    _getLookupId() {
+        const opts = this._scalingOptions;
+        return `${this._src}-${opts.type}-${opts.width}-${opts.height}`;
+    }
+
     _getSourceLoader() {
         let src = this._src;
         if (this.stage.getOption('srcBasePath')) {


### PR DESCRIPTION
…er source.

Following template would use one same texture instead of 4 different ones.

```javascript
const SRC = 'https://previews.123rf.com/images/lkeskinen/lkeskinen1802/lkeskinen180208322/95731150-example-stamp-typographic-label-stamp-or-icon.jpg';
export default class App extends ux.App {
    static _template() {
        return {
            flex: true,
            Cover: {texture: ux.Ui.getImage(SRC, {width: 500, height: 500, type: 'parent'})},
            Cover2: {texture: ux.Ui.getImage(SRC, {width: 100, height: 100, type: 'crop'})},
            Cover3: {texture: ux.Ui.getImage(SRC, {width: 200, height: 100, type: 'crop'})},
            Cover4: {texture: ux.Ui.getImage(SRC, {width: 200, height: 100, type: 'fit'})},
        }
    }
}
```