### PR TITLE
App: Metric and closure changes

### DIFF
--- a/src/Application/index.js
+++ b/src/Application/index.js
@@ -33,7 +33,6 @@ if (window.innerHeight === 720) {
 }
 
 export default function(App, appData, platformSettings) {
-  Metrics.app.launch()
   return class Application extends Lightning.Application {
     constructor(options) {
       const config = Deepmerge(defaultOptions, options)
@@ -86,15 +85,22 @@ export default function(App, appData, platformSettings) {
     }
 
     closeApp() {
-      Log.info('Closing App')
       if (platformSettings.onClose && typeof platformSettings.onClose === 'function') {
-        Metrics.app.close()
         platformSettings.onClose()
+      } else {
+        this.close()
       }
+    }
+
+    close() {
+      Log.info('Closing App')
+      Metrics.app.close()
+
       this.childList.remove(this.tag('App'))
 
       // force texture garbage collect
       this.stage.gc()
+      this.destroy()
     }
 
     loadFonts(fonts) {

--- a/src/Application/index.js
+++ b/src/Application/index.js
@@ -94,8 +94,6 @@ export default function(App, appData, platformSettings) {
 
     close() {
       Log.info('Closing App')
-      Metrics.app.close()
-
       this.childList.remove(this.tag('App'))
 
       // force texture garbage collect


### PR DESCRIPTION
Split out closeApp and the cleanup, this allows the bootstrapper to call
close externally. 

Add this.destroy() to trigger lightning cleanup, so we do some GC before
exiting. 

Move launch/close metric to bootstrapper.